### PR TITLE
feature/conversion-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# TrackLogAPI_Console
+Usage of the Facebook CAPI library
+==================================
+
+* Setup the FacebookToken and FacebookPixelId values in App.config.
+* There is an Adapter class FacebookDataConverter which converts the data attributes into Facebook format.
+* Usage of the Library is as follows,
+
+FacebookEvent ev = FacebookDataConverter.parseItemData(item);
+
+if (ev != null)
+{
+	FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, fbc);
+        eventRequest.addEventItem(ev);
+        eventRequest.execute();
+}
+
+* Facebook is going to make client_user_agent, action_source, and event_source_url mandatory for all requests. Ref: https://developers.facebook.com/docs/marketing-api/conversions-api/
+* Currently the libaray sets the action_source as website by default, users can override this setting by having an action_source property on model class and setting it to another value.

--- a/TrackLogAPIConsole/App.config
+++ b/TrackLogAPIConsole/App.config
@@ -6,6 +6,8 @@
   <appSettings>
     <add key="ApiUrl" value="http://track.hawooo.com/" />
     <add key="Credential" value="HAWOOO" />
+    <add key="FacebookToken" value="HAWOO" />
+    <add key="FacebookPixelId" value="HAWOO" />   
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/TrackLogAPIConsole/App.config
+++ b/TrackLogAPIConsole/App.config
@@ -6,8 +6,8 @@
   <appSettings>
     <add key="ApiUrl" value="http://track.hawooo.com/" />
     <add key="Credential" value="HAWOOO" />
-    <add key="FacebookToken" value="HAWOO" />
-    <add key="FacebookPixelId" value="HAWOO" />   
+    <add key="FacebookToken" value="HAWOOO" />
+    <add key="FacebookPixelId" value="HAWOOO" />   
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/TrackLogAPIConsole/Classes/CallWebAPI.cs
+++ b/TrackLogAPIConsole/Classes/CallWebAPI.cs
@@ -1,18 +1,34 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 using System.Text.Json;
-using TrackLogAPIConsole.Models;
+using System.Threading.Tasks;
 using System.Web.Script.Serialization;
+using TP_CAPI.Libraries;
+using TP_CAPI.Models;
+using TrackLogAPIConsole.Models;
 
 namespace TrackLogAPIConsole.Classes
 {
     class CallWebAPI
     {
+        private FacebookClient facebookClient;
+        private string facebookToken;
+        private string facebookPixelId;
+
+        public CallWebAPI()
+        {
+            facebookToken = ConfigurationManager.AppSettings["FacebookToken"];
+            facebookPixelId = ConfigurationManager.AppSettings["FacebookPixelId"];
+
+            facebookClient = new FacebookClient(facebookToken);
+        }
+
+
         public bool CallAddtoCartAPI(APIConfigurations api)
         {
 
@@ -53,6 +69,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("browserid:" + item.browserid);
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
+
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
 
                     }
                     Console.WriteLine("=============== End Result=============");
@@ -102,6 +127,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
 
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
+
                     }
                     Console.WriteLine("=============== End Result=============");
                 }
@@ -121,8 +155,7 @@ namespace TrackLogAPIConsole.Classes
                 webClient.BaseAddress = api.APIUrl;
                 webClient.Headers["Content-type"] = "application/json";
                 webClient.Encoding = Encoding.UTF8;
-                webClient.Headers.Add(HttpRequestHeader.Authorization,
-    Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes(api.Credentials)));
+                webClient.Headers.Add(HttpRequestHeader.Authorization, Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes(api.Credentials)));
                 var json = webClient.DownloadString(api.APIfunc);
 
                 List<PurchaseModel> itemlst = JsonSerializer.Deserialize<List<PurchaseModel>>(json);
@@ -151,6 +184,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("browserid:" + item.browserid);
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
+
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
 
                     }
                     Console.WriteLine("=============== End Result=============");
@@ -204,6 +246,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
 
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
+
                     }
                     Console.WriteLine("=============== End Result=============");
                 }
@@ -254,6 +305,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("browserid:" + item.browserid);
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
+
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
 
                     }
                     Console.WriteLine("=============== End Result=============");
@@ -308,6 +368,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
 
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
+
                     }
                     Console.WriteLine("=============== End Result=============");
                 }
@@ -357,6 +426,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("browserid:" + item.browserid);
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
+
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
 
                     }
                     Console.WriteLine("=============== End Result=============");
@@ -408,6 +486,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
 
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
+
                     }
                     Console.WriteLine("=============== End Result=============");
                 }
@@ -458,6 +545,15 @@ namespace TrackLogAPIConsole.Classes
                         Console.WriteLine("browserid:" + item.browserid);
                         Console.WriteLine("fb_loginid :" + item.fb_loginid);
                         Console.WriteLine("\n");
+
+                        FacebookEvent facebookEvent = FacebookDataConverter.parseItemData(item);
+
+                        if (facebookEvent != null)
+                        {
+                            FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, facebookClient);
+                            eventRequest.addEventItem(facebookEvent);
+                            eventRequest.execute();
+                        }
 
                     }
                     Console.WriteLine("=============== End Result=============");

--- a/TrackLogAPIConsole/Program.cs
+++ b/TrackLogAPIConsole/Program.cs
@@ -228,7 +228,5 @@ namespace TrackLogAPIConsole
 
             return true;
         }
-
-
     }
 }

--- a/TrackLogAPIConsole/TP/CAPI/Libraries/FacebookClient.cs
+++ b/TrackLogAPIConsole/TP/CAPI/Libraries/FacebookClient.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Text.Json;
+using System.Net;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Security.Cryptography;
+using System.Collections.Specialized;
+using System.Net.Http;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+
+namespace TP_CAPI.Libraries
+{
+    public class FacebookClient
+    {
+        private const string apiVersion = "9.0";
+        private const string BASE_URL = "https://graph.facebook.com/v" + apiVersion + "/";
+
+        private string accessToken;
+
+        public FacebookClient(string accessToken)
+        {
+            this.accessToken = accessToken;
+        }
+
+        public async Task<HttpResponseMessage> postAsync(string payload, string endpoint)
+        {
+            using (HttpClient httpClient = new HttpClient())
+            {
+                httpClient.BaseAddress = new Uri(BASE_URL);
+
+                Dictionary<string, string> paramData = new Dictionary<string, string>
+                {
+                    { "access_token",  accessToken },
+                    { "data", payload }
+                };
+
+                HttpResponseMessage responseMessage;
+
+                var encodedContent = new FormUrlEncodedContent(paramData);
+                responseMessage = await httpClient.PostAsync(endpoint, encodedContent);
+                responseMessage.EnsureSuccessStatusCode();
+
+                return responseMessage;
+            }
+        }
+    }
+}

--- a/TrackLogAPIConsole/TP/CAPI/Libraries/FacebookDataConverter.cs
+++ b/TrackLogAPIConsole/TP/CAPI/Libraries/FacebookDataConverter.cs
@@ -1,0 +1,467 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using TrackLogAPIConsole.Models;
+using TP_CAPI.Models;
+
+namespace TP_CAPI.Libraries
+{
+    public class FacebookDataConverter
+    {
+        public FacebookDataConverter()
+        {
+        }
+
+        public static FacebookEvent parseItemData(Object model)
+        {
+            FacebookEvent facebookEvent = null;
+
+            if (model is AddtoCartModel)
+            {
+                AddtoCartModel item = (AddtoCartModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.total_value.ToString(CultureInfo.InvariantCulture);
+                customData.contentType = "product";
+
+                List<string> productIds = new List<string>();
+
+                foreach (products product in item.products)
+                {
+                    productIds.Add(product.productid.ToString(CultureInfo.InvariantCulture));
+                }
+
+                customData.contentIds = productIds;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "AddToCart";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null) {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is AddToWishlistModel)
+            {
+                AddToWishlistModel item = (AddToWishlistModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.value.ToString(CultureInfo.InvariantCulture);
+                customData.contentType = "product";
+
+                List<string> productIds = new List<string>();
+
+                foreach (products product in item.products)
+                {
+                    productIds.Add(product.productid.ToString(CultureInfo.InvariantCulture));
+                }
+
+                customData.contentIds = productIds;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "AddToWishlist";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is CompleteRegistrationModel)
+            {
+                CompleteRegistrationModel item = (CompleteRegistrationModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.contentName = item.content_name;
+                customData.status = item.reg_status;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "CompleteRegistration";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is InitiateCheckoutModel)
+            {
+                InitiateCheckoutModel item = (InitiateCheckoutModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.total_value.ToString(CultureInfo.InvariantCulture);
+                customData.contentType = "product";
+
+                List<string> productIds = new List<string>();
+
+                foreach (products product in item.products)
+                {
+                    productIds.Add(product.productid.ToString(CultureInfo.InvariantCulture));
+                }
+
+                customData.contentIds = productIds;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "InitiateCheckout";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is PageViewModel)
+            {
+                PageViewModel item = (PageViewModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "PageView";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is PurchaseModel)
+            {
+                PurchaseModel item = (PurchaseModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.total_value.ToString(CultureInfo.InvariantCulture);
+                customData.contentType = "product";
+
+                List<string> productIds = new List<string>();
+
+                foreach (products product in item.products)
+                {
+                    productIds.Add(product.productid.ToString(CultureInfo.InvariantCulture));
+                }
+
+                customData.contentIds = productIds;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "Purchase";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is SearchModel)
+            {
+                SearchModel item = (SearchModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.value.ToString(CultureInfo.InvariantCulture);
+                customData.searchString = item.search_str;
+                customData.contentType = "product";
+
+                List<string> productIds = new List<string>();
+
+                foreach (products product in item.products)
+                {
+                    productIds.Add(product.productid.ToString(CultureInfo.InvariantCulture));
+                }
+
+                customData.contentIds = productIds;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "Search";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is SubscribeModel)
+            {
+                SubscribeModel item = (SubscribeModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.value.ToString(CultureInfo.InvariantCulture);
+                customData.predictedLtv = item.predicted_itv;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "Subscribe";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+            else if (model is AddPaymentInfoModel)
+            {
+                AddPaymentInfoModel item = (AddPaymentInfoModel)model;
+
+                FacebookUserData userData = new FacebookUserData();
+                userData.email = item.email;
+                userData.firstName = item.first_name;
+                userData.lastName = item.last_name;
+                userData.phone = item.phone;
+                userData.dob = item.dob;
+                userData.city = item.city;
+                userData.state = item.state;
+                userData.country = item.country;
+                userData.clientIpAddress = item.user_ip;
+                userData.clientUserAgent = item.browser_user_agent;
+                userData.fbLoginId = item.fb_loginid;
+                userData.clickId = item.clickid;
+                userData.browserId = item.browserid;
+
+                FacebookCustomData customData = new FacebookCustomData();
+                customData.currency = item.currency;
+                customData.value = item.value.ToString(CultureInfo.InvariantCulture);
+                customData.contentType = "product";
+
+                List<string> productIds = new List<string>();
+
+                foreach (products product in item.products)
+                {
+                    productIds.Add(product.productid.ToString(CultureInfo.InvariantCulture));
+                }
+
+                customData.contentIds = productIds;
+
+                FacebookEvent fbEvent = new FacebookEvent();
+                fbEvent.eventName = "AddPaymentInfo";
+                fbEvent.eventId = item.eventid.ToString(CultureInfo.InvariantCulture);
+                long nw = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                nw = nw / 1000;
+
+                fbEvent.eventTime = nw.ToString();
+                fbEvent.eventSourceUrl = item.url;
+
+                if (item.GetType().GetProperty("action_source") != null)
+                {
+                    fbEvent.actionSource = item.GetType().GetProperty("action_source").ToString();
+                }
+
+                //Setting user and custom data
+                fbEvent.userData = userData;
+                fbEvent.customData = customData;
+
+                facebookEvent = fbEvent;
+            }
+
+            return facebookEvent;
+        }
+    }
+}

--- a/TrackLogAPIConsole/TP/CAPI/Libraries/FacebookEventRequest.cs
+++ b/TrackLogAPIConsole/TP/CAPI/Libraries/FacebookEventRequest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using TrackLogAPIConsole.Models;
+using System.Text;
+using System.Text.Json;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using System.Net;
+using TP_CAPI.Libraries;
+using System.Net.Http;
+using TP_CAPI.Models;
+
+namespace TP_CAPI.Libraries
+{
+    public class FacebookEventRequest
+    {
+        private const string eventsEndpoint = "events";
+
+        private string pixelId;
+        private FacebookClient client;
+        private List<FacebookEvent> events;
+        
+
+        public FacebookEventRequest(string pixelId, FacebookClient client)
+        {
+            this.client = client;
+            this.pixelId = pixelId;
+
+            events = new List<FacebookEvent>();
+        }
+
+        public void addEventItem(FacebookEvent e)
+        {
+            events.Add(e);
+        }
+
+        public void execute()
+        {
+          
+            foreach (FacebookEvent e in events)
+            {
+                string data = e.toJsonString();
+
+                try {
+                    this.client.postAsync(data, this.pixelId + "/" + eventsEndpoint).Wait();
+                } catch (Exception ex) {
+                    Console.WriteLine(ex.Message);
+                }
+            }
+                
+        }
+
+        public static string toSHA256(string value)
+        {
+            if (value == null) return null;
+            StringBuilder Sb = new StringBuilder();
+            using (var hash = SHA256.Create())
+            {
+                Encoding enc = Encoding.UTF8;
+                Byte[] result = hash.ComputeHash(enc.GetBytes(value));
+
+                foreach (Byte b in result)
+                    Sb.Append(b.ToString("x2"));
+            }
+
+            return Sb.ToString();
+        }
+    }
+}

--- a/TrackLogAPIConsole/TP/CAPI/Models/FacebookCustomData.cs
+++ b/TrackLogAPIConsole/TP/CAPI/Models/FacebookCustomData.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Text;
+using System.Xml;
+using System.Text.Json;
+using System.Collections.Generic;
+
+namespace TP_CAPI.Models
+{
+    public class FacebookCustomData
+    {
+        public string value { get; set; }
+        public string currency { get; set; }
+        public List<string> contentIds { get; set; }
+        public string contentType { get; set; }
+        public string contentName { get; set; }
+        public string contentCategory { get; set; }
+        public string status { get; set; }
+        public string searchString { get; set; }
+        public string predictedLtv { get; set; }
+
+
+        public Dictionary<string, Object> toArray()
+        {
+
+            Dictionary<string, Object> ret = new Dictionary<string, Object>();
+
+            if (currency != null)
+                ret.Add("currency", currency);
+            if (value != null)
+                ret.Add("value", value);
+            if(contentIds != null)
+                ret.Add("content_ids", contentIds);
+            if (contentType != null)
+                ret.Add("content_type", contentType);
+            if (contentName != null)
+                ret.Add("content_name", contentName);
+            if (status != null)
+                ret.Add("status", status);
+            if (contentCategory != null)
+                ret.Add("content_category", contentCategory);
+            if (searchString != null)
+                ret.Add("search_string", searchString);
+            if (predictedLtv != null)
+                ret.Add("predicted_ltv", predictedLtv);
+
+            return ret;
+        }
+    }
+}

--- a/TrackLogAPIConsole/TP/CAPI/Models/FacebookEvent.cs
+++ b/TrackLogAPIConsole/TP/CAPI/Models/FacebookEvent.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using System.Xml;
+using System.Text.Json;
+
+namespace TP_CAPI.Models
+{
+    public class FacebookEvent
+    {
+        public string eventName { get; set; }
+        public string eventId { get; set; }
+        public string eventTime { get; set; }
+        public string eventSourceUrl { get; set; }
+        public string actionSource { get; set; }
+
+        public FacebookUserData userData { get; set; }
+        public FacebookCustomData customData { get; set; }
+        public bool optOut { get; set; }
+
+        public string toJsonString()
+        {
+            string str;
+
+            Dictionary<string, Object> ret = new Dictionary<string, Object>();
+
+            if (eventId != null)
+                ret.Add("event_id", eventId);
+
+            if (actionSource != null)
+            {
+                ret.Add("action_source", actionSource);
+            }
+            else {
+                //Default parameter
+                ret.Add("action_source", "website");
+            }
+               
+            ret.Add("event_name", eventName);
+            ret.Add("event_time", eventTime);
+            ret.Add("opt_out", optOut.ToString().ToLower());
+
+            if (eventSourceUrl != null)
+                ret.Add("event_source_url", eventSourceUrl);
+
+            if (userData != null)
+                ret.Add("user_data", userData.toArray());
+            if (customData != null)
+                ret.Add("custom_data", customData.toArray());
+
+            List<Object> data = new List<Object>();
+            data.Add(ret);
+
+            str = JsonSerializer.Serialize(data);
+
+            return str;
+        }
+    }
+}

--- a/TrackLogAPIConsole/TP/CAPI/Models/FacebookUserData.cs
+++ b/TrackLogAPIConsole/TP/CAPI/Models/FacebookUserData.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using System.Xml;
+using System.Text.Json;
+using TP_CAPI.Libraries;
+
+namespace TP_CAPI.Models
+{
+    public class FacebookUserData
+    {
+        public string clientIpAddress { get; set; }
+        public string clientUserAgent { get; set; }
+        //Must be hashed
+        public string email { get; set; }
+        //Must be hashed
+        public string phone { get; set; }
+        //Must be hashed
+        public string city { get; set; }
+        //Must be hashed
+        public string state { get; set; }
+        //Must be hashed
+        public string country { get; set; }
+        //Must be hashed
+        public string firstName { get; set; }
+        //Must be hashed
+        public string lastName { get; set; }
+        //Must be hashed
+        public string gender { get; set;  }
+        //Must be hashed
+        public string zip { get; set; }
+        //Must be hashed
+        public string dob { get; set; }
+
+        //Click ID
+        public string clickId { get; set; }
+        //Browser ID
+        public string browserId { get; set; }
+
+        public string fbLoginId { get; set; }
+
+        public Dictionary<string, string> toArray()
+        {
+            Dictionary<string, string> ret = new Dictionary<string, string>();
+
+            if(clientUserAgent != null && clientUserAgent.Length > 0)
+                ret.Add("client_user_agent", clientUserAgent);
+            if (clientIpAddress != null && clientIpAddress.Length > 0)
+                ret.Add("client_ip_address", clientIpAddress);
+
+            if (email != null && email.Length > 0)
+                ret.Add("em", FacebookEventRequest.toSHA256(email));
+            if (phone != null && phone.Length > 0)
+                ret.Add("ph", FacebookEventRequest.toSHA256(phone));
+            if (city != null && city.Length > 0)
+                ret.Add("ct", FacebookEventRequest.toSHA256(city));
+            if (country != null && country.Length > 0)
+                ret.Add("country", FacebookEventRequest.toSHA256(country));
+            if (firstName != null && firstName.Length > 0)
+                ret.Add("fn", FacebookEventRequest.toSHA256(firstName));
+            if (lastName != null && lastName.Length > 0)
+                ret.Add("ln", FacebookEventRequest.toSHA256(lastName));
+            if (gender != null && gender.Length > 0)
+                ret.Add("ge", FacebookEventRequest.toSHA256(gender));
+            if (zip != null && zip.Length > 0)
+                ret.Add("zp", FacebookEventRequest.toSHA256(zip));
+            if (dob != null && dob.Length > 0)
+                ret.Add("db", FacebookEventRequest.toSHA256(dob));
+            if (state != null && state.Length > 0)
+                ret.Add("st", FacebookEventRequest.toSHA256(state));
+
+            if (clickId != null && clickId.Length > 0)
+                ret.Add("fbc", clickId);
+            if (browserId != null && browserId.Length > 0)
+                ret.Add("fbp", browserId);
+            if (fbLoginId != null && fbLoginId.Length > 0)
+                ret.Add("fb_login_id", fbLoginId);
+
+            return ret;
+        }
+    }
+}

--- a/TrackLogAPIConsole/TrackLogAPIConsole.csproj
+++ b/TrackLogAPIConsole/TrackLogAPIConsole.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -88,11 +88,23 @@
     <Compile Include="Models\SubscribeModel.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TP\CAPI\Models\FacebookCustomData.cs" />
+    <Compile Include="TP\CAPI\Models\FacebookEvent.cs" />
+    <Compile Include="TP\CAPI\Models\FacebookUserData.cs" />
+    <Compile Include="TP\CAPI\Libraries\FacebookDataConverter.cs" />
+    <Compile Include="TP\CAPI\Libraries\FacebookClient.cs" />
+    <Compile Include="TP\CAPI\Libraries\FacebookEventRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
+  <ItemGroup>
+    <Folder Include="TP\" />
+    <Folder Include="TP\CAPI\" />
+    <Folder Include="TP\CAPI\Models\" />
+    <Folder Include="TP\CAPI\Libraries\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Usage of the Facebook CAPI library
==================================

* Setup the FacebookToken and FacebookPixelId values in App.config.
* There is an Adapter class FacebookDataConverter which converts the data attributes into Facebook format.
* Usage of the Library is as follows,

```
FacebookEvent ev = FacebookDataConverter.parseItemData(item);

if (ev != null)
{
	FacebookEventRequest eventRequest = new FacebookEventRequest(facebookPixelId, fbc);
        eventRequest.addEventItem(ev);
        eventRequest.execute();
}
```

* Facebook is going to make client_user_agent, action_source, and event_source_url mandatory for all requests. Ref: https://developers.facebook.com/docs/marketing-api/conversions-api/
* Currently the library sets the action_source as website by default, users can override this setting by having an action_source property on model class and setting it to another value.
